### PR TITLE
Fix #30 Add zapcore.ArrayMarshalerType encoder

### DIFF
--- a/otelzap/arrayEncoder.go
+++ b/otelzap/arrayEncoder.go
@@ -7,9 +7,14 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// bufferArrayEncoder implements zapcore.bufferArrayEncoder.
+// It represents all added objects to their string values and
+// adds them to the stringsSlice buffer.
 type bufferArrayEncoder struct {
 	stringsSlice []string
 }
+
+var _ zapcore.ArrayEncoder = (*bufferArrayEncoder)(nil)
 
 func (t *bufferArrayEncoder) AppendComplex128(v complex128) {
 	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
@@ -79,7 +84,7 @@ func (t *bufferArrayEncoder) AppendInt8(v int8) {
 }
 
 func (t *bufferArrayEncoder) AppendString(v string) {
-	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+	t.stringsSlice = append(t.stringsSlice, v)
 }
 
 func (t *bufferArrayEncoder) AppendTime(v time.Time) {

--- a/otelzap/arrayEncoder.go
+++ b/otelzap/arrayEncoder.go
@@ -1,0 +1,111 @@
+package otelzap
+
+import (
+	"fmt"
+	"time"
+
+	"go.uber.org/zap/zapcore"
+)
+
+type bufferArrayEncoder struct {
+	stringsSlice []string
+}
+
+func (t *bufferArrayEncoder) AppendComplex128(v complex128) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendComplex64(v complex64) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendArray(v zapcore.ArrayMarshaler) error {
+	enc := &bufferArrayEncoder{}
+	err := v.MarshalLogArray(enc)
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", enc.stringsSlice))
+	return err
+}
+
+func (t *bufferArrayEncoder) AppendObject(v zapcore.ObjectMarshaler) error {
+	m := zapcore.NewMapObjectEncoder()
+	err := v.MarshalLogObject(m)
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", m.Fields))
+	return err
+}
+
+func (t *bufferArrayEncoder) AppendReflected(v interface{}) error {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+	return nil
+}
+
+func (t *bufferArrayEncoder) AppendBool(v bool) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendByteString(v []byte) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendDuration(v time.Duration) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendFloat64(v float64) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendFloat32(v float32) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendInt(v int) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendInt64(v int64) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendInt32(v int32) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendInt16(v int16) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendInt8(v int8) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendString(v string) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendTime(v time.Time) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendUint(v uint) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendUint64(v uint64) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendUint32(v uint32) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendUint16(v uint16) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendUint8(v uint8) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}
+
+func (t *bufferArrayEncoder) AppendUintptr(v uintptr) {
+	t.stringsSlice = append(t.stringsSlice, fmt.Sprintf("%v", v))
+}

--- a/otelzap/option.go
+++ b/otelzap/option.go
@@ -42,7 +42,7 @@ func WithStackTrace(on bool) Option {
 	}
 }
 
-// WithTraceID configures the logger to add `trace_id` field to structured log messages.
+// WithTraceIDField configures the logger to add `trace_id` field to structured log messages.
 //
 // This option is only useful with backends that don't support OTLP and instead parse log
 // messages to extract structured information.


### PR DESCRIPTION
This MR fixes #30. The commit message is pretty clear. Feel free to update the wording.

I added 2 test cases: for the simplest case with an array of strings and the complex one with an array of durations. IMO other cases should work without any issues as well.