### PR TITLE
fix(otelzap): WithOptions(zap.Fields(...)) will keep fields with logger

### DIFF
--- a/otelzap/fieldextractor.go
+++ b/otelzap/fieldextractor.go
@@ -1,0 +1,39 @@
+package otelzap
+
+import (
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// fieldExtractorCore copy zapcore.Fields from With method to extraFields list
+type fieldExtractorCore struct {
+	extraFields *[]zap.Field
+}
+
+var _ zapcore.Core = (*fieldExtractorCore)(nil)
+
+// With adds structured context to the Core.
+func (fe *fieldExtractorCore) With(fs []zapcore.Field) zapcore.Core {
+	*fe.extraFields = append(*fe.extraFields, fs...)
+	return nil
+}
+
+// Check stub
+func (*fieldExtractorCore) Check(zapcore.Entry, *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return nil
+}
+
+// Write stub
+func (*fieldExtractorCore) Write(zapcore.Entry, []zapcore.Field) error {
+	return nil
+}
+
+// Sync stub
+func (*fieldExtractorCore) Sync() error {
+	return nil
+}
+
+// Enabled stub
+func (*fieldExtractorCore) Enabled(zapcore.Level) bool {
+	return false
+}


### PR DESCRIPTION
This MR fixes https://github.com/uptrace/opentelemetry-go-extra/issues/32

I added a test case that creates 2 loggers:
- the 1st one adds `baz` field and wraps the original logger
- the 2nd one adds `faz` field and wraps the 1st one