### PR TITLE
Updated otelgorm to not include query variables by default

### DIFF
--- a/otelgorm/option.go
+++ b/otelgorm/option.go
@@ -28,3 +28,10 @@ func WithDBName(name string) Option {
 		p.attrs = append(p.attrs, semconv.DBNameKey.String(name))
 	}
 }
+
+// WithQueryVariables configures the db.statement attribute to include query variables
+func WithQueryVariables() Option {
+	return func(p *otelPlugin) {
+		p.includeQueryVars = true
+	}
+}

--- a/otelgorm/otelgorm.go
+++ b/otelgorm/otelgorm.go
@@ -17,9 +17,10 @@ import (
 var dbRowsAffected = attribute.Key("db.rows_affected")
 
 type otelPlugin struct {
-	provider trace.TracerProvider
-	tracer   trace.Tracer
-	attrs    []attribute.KeyValue
+	provider         trace.TracerProvider
+	tracer           trace.Tracer
+	attrs            []attribute.KeyValue
+	includeQueryVars bool
 }
 
 func NewPlugin(opts ...Option) gorm.Plugin {
@@ -107,7 +108,19 @@ func (p *otelPlugin) after() gormHookFunc {
 		if sys := dbSystem(tx); sys.Valid() {
 			attrs = append(attrs, sys)
 		}
-		query := tx.Dialector.Explain(tx.Statement.SQL.String(), tx.Statement.Vars...)
+
+		vars := tx.Statement.Vars
+		if !p.includeQueryVars {
+			// Replace query variables with '?'
+			vars = make([]interface{}, len(tx.Statement.Vars))
+
+			for i := 0; i < len(vars); i++ {
+				vars[i] = "?"
+			}
+		}
+
+		query := tx.Dialector.Explain(tx.Statement.SQL.String(), vars...)
+
 		attrs = append(attrs, semconv.DBStatementKey.String(query))
 
 		if tx.Statement.Table != "" {


### PR DESCRIPTION
This PR adds an option to otelgorm to include query variables in the `db.statement` attribute. I noticed that query variables were being included by default, but this may not be suitable for most users as query variables can contain sensitive values and would be a security issue if included in traces. For that reason, I've made including query variables opt-in.

Before:
```
SELECT "x" FROM "y" WHERE email_address = 'alice@wonderland.com'

UPDATE "z" SET "address"='123 Canwefixit Street' WHERE "user_id" = 'bobthebuilder'
```

After:
```
SELECT "x" FROM "y" WHERE email_address = '?'

UPDATE "z" SET "address"='?' WHERE "user_id" = '?'
```