### PR TITLE
feat(otelgorm): added an option to not report DB stats metrics

### DIFF
--- a/otelgorm/option.go
+++ b/otelgorm/option.go
@@ -35,3 +35,10 @@ func WithoutQueryVariables() Option {
 		p.excludeQueryVars = true
 	}
 }
+
+// WithoutMetrics prevents DBStats metrics from being reported.
+func WithoutMetrics() Option {
+	return func(p *otelPlugin) {
+		p.excludeMetrics = true
+	}
+}

--- a/otelgorm/otelgorm.go
+++ b/otelgorm/otelgorm.go
@@ -21,6 +21,7 @@ type otelPlugin struct {
 	tracer           trace.Tracer
 	attrs            []attribute.KeyValue
 	excludeQueryVars bool
+	excludeMetrics   bool
 }
 
 func NewPlugin(opts ...Option) gorm.Plugin {
@@ -48,8 +49,10 @@ type gormRegister interface {
 }
 
 func (p otelPlugin) Initialize(db *gorm.DB) (err error) {
-	if db, ok := db.ConnPool.(*sql.DB); ok {
-		otelsql.ReportDBStatsMetrics(db)
+	if !p.excludeMetrics {
+		if db, ok := db.ConnPool.(*sql.DB); ok {
+			otelsql.ReportDBStatsMetrics(db)
+		}
 	}
 
 	cb := db.Callback()


### PR DESCRIPTION
This PR adds an option to otelgorm to not report DB stats metrics. Some users like myself may not be currently using OpenTelemetry for metrics and wish to be able to disable this functionality. This functionality might also overlap or conflict with the Prometheus plugin for gorm: https://gorm.io/docs/prometheus.html