### PR TITLE
fix: set span kind to client for otelgorm

### DIFF
--- a/otelgorm/internal/e2etest/e2e_test.go
+++ b/otelgorm/internal/e2etest/e2e_test.go
@@ -33,6 +33,7 @@ func TestEndToEnd(t *testing.T) {
 			require: func(t *testing.T, spans []sdktrace.ReadOnlySpan) {
 				require.Equal(t, 1, len(spans))
 				require.Equal(t, "gorm.Row", spans[0].Name())
+				require.Equal(t, trace.SpanKindClient, spans[0].SpanKind())
 
 				m := attrMap(spans[0].Attributes())
 

--- a/otelgorm/internal/e2etest/e2e_test.go
+++ b/otelgorm/internal/e2etest/e2e_test.go
@@ -11,6 +11,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
+	"go.opentelemetry.io/otel/trace"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 

--- a/otelgorm/otelgorm.go
+++ b/otelgorm/otelgorm.go
@@ -96,7 +96,7 @@ func (p otelPlugin) Initialize(db *gorm.DB) (err error) {
 
 func (p *otelPlugin) before(spanName string) gormHookFunc {
 	return func(tx *gorm.DB) {
-		tx.Statement.Context, _ = p.tracer.Start(tx.Statement.Context, spanName)
+		tx.Statement.Context, _ = p.tracer.Start(tx.Statement.Context, spanName, trace.WithSpanKind(trace.SpanKindClient))
 	}
 }
 


### PR DESCRIPTION
As the title says, this adds the span kind to CLIENT for otelgorm instrumentation library.