### PR TITLE
Know 1 support google cloud trace

### DIFF
--- a/otelzap/option.go
+++ b/otelzap/option.go
@@ -51,3 +51,14 @@ func WithTraceIDField(on bool) Option {
 		l.withTraceID = on
 	}
 }
+
+// WithSetTraceFieldsFunc configures the logger to run the given function on every log message to allow
+// setting further zap fields based on the span context information
+//
+// This is useful for setting stackdriver tracing information
+//
+func WithSetTraceFieldsFunc(cb SetTraceFieldsFunc) Option {
+	return func(l *Logger) {
+		l.setTraceFieldsFunc = cb
+	}
+}

--- a/otelzap/otelzap.go
+++ b/otelzap/otelzap.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/blendle/zapdriver"
 	"github.com/uptrace/opentelemetry-go-extra/otelutil"
 )
 
@@ -169,8 +170,11 @@ func (l *Logger) logFields(
 	l.log(span, lvl, msg, attrs)
 
 	if l.withTraceID {
-		traceID := span.SpanContext().TraceID().String()
+		spanCtx := span.SpanContext()
+		traceID := spanCtx.TraceID().String()
+		spanID := spanCtx.SpanID().String
 		fields = append(fields, zap.String("trace_id", traceID))
+		fields = append(fields, zapdriver.TraceContext(traceID, spanID, spanCtx.IsSampled(), "googleid"))
 	}
 
 	return fields


### PR DESCRIPTION
Add a new option WithSetTraceFieldsFunc, that allows a caller to set a callabck function that will append zap fields based on the passed span context. 

This allows for instance to use zapdriver to pass a stackdriver compatible trace field object and get linked logs and traces in the google cloudtrace ui