### PR TITLE
fix(otelzap): add missing DebugwContext function

### DIFF
--- a/otelzap/otelzap.go
+++ b/otelzap/otelzap.go
@@ -451,6 +451,15 @@ func (s *SugaredLogger) logArgs(
 	s.l.log(span, lvl, fmt.Sprintf(template, args...), attrs)
 }
 
+// Debugw logs a message with some additional context. The variadic key-value
+// pairs are treated as they are in With.
+func (s *SugaredLogger) DebugwContext(
+	ctx context.Context, msg string, keysAndValues ...interface{},
+) {
+	keysAndValues = s.logKVs(ctx, zap.DebugLevel, msg, keysAndValues)
+	s.Debugw(msg, keysAndValues...)
+}
+
 // Infow logs a message with some additional context. The variadic key-value
 // pairs are treated as they are in With.
 func (s *SugaredLogger) InfowContext(


### PR DESCRIPTION
This pull request adds previously missing `DebugwContext` function to `SugaredLogger`.

Fixes https://github.com/uptrace/opentelemetry-go-extra/issues/63