### PR TITLE
otelzap: do not panic on invalid input

### DIFF
--- a/otelzap/otelzap.go
+++ b/otelzap/otelzap.go
@@ -528,7 +528,7 @@ func (s *SugaredLogger) logKVs(
 
 	attrs := make([]attribute.KeyValue, 0, numAttr+len(kvs))
 
-	for i := 0; i < len(kvs); i += 2 {
+	for i := 0; i < len(kvs)-1; i += 2 {
 		if key, ok := kvs[i].(string); ok {
 			attrs = append(attrs, otelutil.Attribute(key, kvs[i+1]))
 		}

--- a/otelzap/otelzap_test.go
+++ b/otelzap/otelzap_test.go
@@ -267,6 +267,36 @@ func TestOtelZap(t *testing.T) {
 		},
 		{
 			log: func(ctx context.Context, log *Logger) {
+				log.Sugar().InfowContext(ctx, "hello", "foo", "bar")
+			},
+			require: func(t *testing.T, event sdktrace.Event) {
+				m := attrMap(event.Attributes)
+
+				sev, ok := m[logSeverityKey]
+				require.True(t, ok)
+				require.Equal(t, "INFO", sev.AsString())
+
+				msg, ok := m[logMessageKey]
+				require.True(t, ok)
+				require.Equal(t, "hello", msg.AsString())
+
+				foo, ok := m["foo"]
+				require.True(t, ok)
+				require.NotZero(t, foo.AsString())
+
+				requireCodeAttrs(t, m)
+			},
+		},
+		{
+			log: func(ctx context.Context, log *Logger) {
+				log.Sugar().InfowContext(ctx, "sugary logs require keyAndValues to come in pairs", "so this is invalid, but it shouldn't panic")
+			},
+			require: func(t *testing.T, event sdktrace.Event) {
+				// no panic? success!
+			},
+		},
+		{
+			log: func(ctx context.Context, log *Logger) {
 				log.Sugar().Ctx(ctx).Errorf("hello %s", "world")
 			},
 			require: func(t *testing.T, event sdktrace.Event) {


### PR DESCRIPTION
This stops a panic in otelzap code on invalid input — i.e. by providing `Sugar().Infow("foo", "key") // missing , "value"`.