### PR TITLE
feat(otelzap): add dynamic field value resolution

### DIFF
--- a/otelzap/README.md
+++ b/otelzap/README.md
@@ -108,3 +108,7 @@ couple of [options](https://pkg.go.dev/github.com/uptrace/opentelemetry-go-extra
 - `otelzap.WithTraceIDField(true)` configures the logger to add `trace_id` field to structured log
   messages. This option is only useful with backends that don't support OTLP and instead parse log
   messages to extract structured information.
+- `otelzap.WithDynamicFields(func(context.Context) []zap.Field)` configures the logger to resolve 
+  given fields dynamically to structured log messages and to the span log events. This
+  option is useful with backends that requires the trace information to be converted or split into
+  multiple fields.

--- a/otelzap/option.go
+++ b/otelzap/option.go
@@ -59,6 +59,12 @@ func WithExtraFields(fields ...zapcore.Field) Option {
 	}
 }
 
+func WithDynamicFields(fields ...DynamicFields) Option {
+	return func(l *Logger) {
+		l.dynamicFields = append(l.dynamicFields, fields...)
+	}
+}
+
 // WithTraceIDField configures the logger to add `trace_id` field to structured log messages.
 //
 // This option is only useful with backends that don't support OTLP and instead parse log

--- a/otelzap/otelzap_test.go
+++ b/otelzap/otelzap_test.go
@@ -393,6 +393,50 @@ func TestOtelZap(t *testing.T) {
 		require.Equal(t, "bar", contextMap["foo"])
 		require.Equal(t, span.SpanContext().TraceID().String(), contextMap["MyTraceIDKey"])
 	})
+
+	t.Run("providing dynamic fields to be recorded on the span, and logged", func(t *testing.T) {
+		type traceIDKey struct{}
+		sr := tracetest.NewSpanRecorder()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(sr))
+		tracer := provider.Tracer("test")
+
+		ctx := context.Background()
+		ctx, span := tracer.Start(ctx, "main")
+
+		ctx = context.WithValue(ctx, traceIDKey{}, "bar")
+
+		core, observedLogs := observer.New(zap.InfoLevel)
+		logger := New(zap.New(core), WithMinLevel(zap.InfoLevel))
+		loggerWithCtx := logger.Ctx(ctx).Clone(WithDynamicFields(func(ctx context.Context) []zap.Field {
+			value := ctx.Value(traceIDKey{}).(string)
+			return []zap.Field{zap.String("MyTraceIDKey", value)}
+		}))
+		loggerWithCtx.Info("hello")
+
+		span.End()
+
+		spans := sr.Ended()
+		require.Equal(t, 1, len(spans))
+
+		events := spans[0].Events()
+		require.Equal(t, 1, len(events))
+
+		event := events[0]
+		require.Equal(t, "log", event.Name)
+
+		m := attrMap(event.Attributes)
+
+		_, ok := m["MyTraceIDKey"]
+		require.True(t, ok)
+		requireCodeAttrs(t, m)
+
+		require.Equal(t, 1, observedLogs.Len())
+		require.Equal(t, "hello", observedLogs.All()[0].Message)
+		require.Equal(t, zap.InfoLevel, observedLogs.All()[0].Level)
+
+		contextMap := observedLogs.All()[0].ContextMap()
+		require.Equal(t, "bar", contextMap["MyTraceIDKey"])
+	})
 }
 
 func requireCodeAttrs(t *testing.T, m map[attribute.Key]attribute.Value) {


### PR DESCRIPTION
This PR aims to add a possibility to dynamically resolve fields from the provided context and fix #59.

Our use case is that Datadog requires us to provide both the spanId and the traceId to the logged message in the keys `dd.span_id` and `dd.trace_id`. In addition, Datadog expects the trace information to be in another format for traces and logs to be correlated. This change will make it possible for us to configure this transformation in the logger itself instead of providing the transformation in every log message.

Below is a sample implementation for Datadog with this change that will print the converted trace information:
` ERROR   example/main.go:29      hello from zap  {"dd.trace_id": "2730366003796952559", "dd.span_id": "2730366003796952559"}`

```go
func main() {
    l, err := zap.NewDevelopment()
    if err != nil {
        panic(err)
    }
    logger = otelzap.New(l, WithDatadogFields())
    
    ctx, span := tracer.Start(context.Background(), "root")
    defer span.End()

    logger.Ctx(ctx).Error("hello from zap")
}

func WithDatadogFields() otelzap.Option {
	convertTraceId := func(id string) string {
		if len(id) < 16 {
			return ""
		}
		if len(id) > 16 {
			id = id[16:]
		}
		intValue, err := strconv.ParseUint(id, 16, 64)
		if err != nil {
			return ""
		}
		return strconv.FormatUint(intValue, 10)
	}

	return otelzap.WithDynamicFields(func(ctx context.Context) []zap.Field {
		fields := make([]zap.Field, 0)
		span := trace.SpanFromContext(ctx)
		if span.IsRecording() {
			fields = append(fields, zap.String("dd.trace_id", convertTraceId(span.SpanContext().TraceID().String())))
			fields = append(fields, zap.String("dd.span_id", convertTraceId(span.SpanContext().SpanID().String())))
		}
		return fields
	})
}
```
  