### PR TITLE
feat(otelgorm): Ignore DryRun callbacks

### DIFF
--- a/otelgorm/internal/e2etest/e2e_test.go
+++ b/otelgorm/internal/e2etest/e2e_test.go
@@ -81,16 +81,16 @@ func TestEndToEnd(t *testing.T) {
 				db.WithContext(ctx).Session(&gorm.Session{DryRun: true}).Exec("SELECT 1")
 			},
 			require: func(t *testing.T, spans []sdktrace.ReadOnlySpan) {
-				require.Equal(t, 1, len(spans))
+				require.Equal(t, 0, len(spans))
 			},
 		},
 		{
-			options: []otelgorm.Option{otelgorm.WithoutDryRunSpans()},
+			options: []otelgorm.Option{otelgorm.WithDryRunSpans()},
 			do: func(ctx context.Context, db *gorm.DB) {
 				db.WithContext(ctx).Session(&gorm.Session{DryRun: true}).Exec("SELECT 1")
 			},
 			require: func(t *testing.T, spans []sdktrace.ReadOnlySpan) {
-				require.Equal(t, 0, len(spans))
+				require.Equal(t, 1, len(spans))
 			},
 		},
 	}

--- a/otelgorm/option.go
+++ b/otelgorm/option.go
@@ -49,3 +49,12 @@ func WithoutMetrics() Option {
 		p.excludeMetrics = true
 	}
 }
+
+// WithoutDryRunSpans will not add trace spans for "dry run" callback
+// invocations from Gorm. "Dry Run" invocations occur when Gorm is just
+// rendering SQL, but not actually executing it against a database.
+func WithoutDryRunSpans() Option {
+	return func(p *otelPlugin) {
+		p.excludeDryRunSpans = true
+	}
+}

--- a/otelgorm/option.go
+++ b/otelgorm/option.go
@@ -50,11 +50,11 @@ func WithoutMetrics() Option {
 	}
 }
 
-// WithoutDryRunSpans will not add trace spans for "dry run" callback
-// invocations from Gorm. "Dry Run" invocations occur when Gorm is just
-// rendering SQL, but not actually executing it against a database.
-func WithoutDryRunSpans() Option {
+// WithDryRunSpans will add trace spans for "dry run" callback invocations from
+// Gorm. "Dry Run" invocations occur when Gorm is just rendering SQL, but not
+// actually executing it against a database.
+func WithDryRunSpans() Option {
 	return func(p *otelPlugin) {
-		p.excludeDryRunSpans = true
+		p.includeDryRunSpans = true
 	}
 }


### PR DESCRIPTION
**This PR:**

Causes the plugin to not create spans when Gorm makes callbacks with sessions marked as [`DryRun`](https://gorm.io/docs/gorm_config.html#DryRun). This is technically a backwards-incompatible change, as users will not see the same spans emitted as before (see below for rationale).

It also adds in a new `WithDryRunSpans()` option for otelgorm. When this option is enabled, functionality reverts to how the plugin operated prior (e.g., adding spans for `DryRun` callbacks).

**Why:**

There are times that Gorm will trigger the `Query()` callback with `DryRun` specified. This is often because either the user has asked for a SQL query to be rendered but not run, or in our case because Gorm makes multiple `Query()` calls to render the various subqueries making up a larger query. This causes spurious spans being created for what isn't even a call to the database. We would rather not see these spans, as we mostly care about the times we ARE making a request to a database.

Here is an example of one of our traces currently. During the request, we run 8 SQL queries, but there are 20 total spans generated. The group of 12 spans on the bottom don't represent calls to the database, but instead rendering of subqueries.

<img width="1212" alt="image" src="https://user-images.githubusercontent.com/113933455/202825210-faf5265b-5790-4f6f-8e37-68c439cbc771.png">

Here is what this trace looks like as a result of the change. Now, only the 8 queries that hit the database are shown.

<img width="1214" alt="image" src="https://user-images.githubusercontent.com/113933455/202825192-6654ec66-d57c-41e5-a580-161a0cc86453.png">

This change would cause DryRun callbacks to not create spans by default, but instead adds for an option to enable creating spans in these cases. This is technically a backwards-incompatible change, but probably one that most users want.