### PR TITLE
fix(otelgorm): restore original context in "after" callback

### DIFF
--- a/otelgorm/internal/e2etest/e2e_test.go
+++ b/otelgorm/internal/e2etest/e2e_test.go
@@ -93,6 +93,22 @@ func TestEndToEnd(t *testing.T) {
 				require.Equal(t, 1, len(spans))
 			},
 		},
+		{
+			do: func(ctx context.Context, db *gorm.DB) {
+				var count int64
+				query := db.WithContext(ctx).Table("generate_series(1, 10)")
+				_, _ = query.Select("*").Rows()
+				_ = query.Count(&count)
+			},
+			require: func(t *testing.T, spans []sdktrace.ReadOnlySpan) {
+				require.Equal(t, 2, len(spans))
+				require.Equal(
+					t,
+					spans[0].Parent().SpanID().String(),
+					spans[1].Parent().SpanID().String(),
+				)
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
**This PR**

Ensures that the `tx.Statement.Context` value that was present when the `before` callback is called is restored after the `after` callback is finished. This fixes #84, which would cause subsequent queries built using the same statement to be seen in children spans.

**Why**

Issue #84 explains how, when the same statement is used for multiple executions, then each execution will be created in a span that is seen as a child of the last. This can often happen when a user of gorm make a query using the query builder API, runs the query, then continues using the original builder to run a slightly modified version of the query.

Below shows an example of the problems this causes. The last three query spans are seen as children to the query before it, when in actuality only the final two should have a parent-child relationship (due to the final query being an eager load).

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/113933455/203175054-481b9402-1757-4f36-95c6-78fa196f0f96.png">

When using this branch, the context is restored and thus the lineage is correct. The below image shows the results.

<img width="994" alt="image" src="https://user-images.githubusercontent.com/113933455/203174814-d703780c-117b-44f1-b9e2-a2cd058d3dbf.png">

**Note:** Failures appear to be due to main branch.