### PR TITLE
fix(otelsql): the connection to db must be closed after receiving the driver

### DIFF
--- a/otelsql/driver.go
+++ b/otelsql/driver.go
@@ -21,6 +21,12 @@ func Open(driverName, dsn string, opts ...Option) (*sql.DB, error) {
 
 func patchDB(db *sql.DB, dsn string, opts ...Option) (*sql.DB, error) {
 	dbDriver := db.Driver()
+
+	err := db.Close()
+	if err != nil {
+		return nil, err
+	}
+
 	d := newDriver(dbDriver, opts)
 
 	if _, ok := dbDriver.(driver.DriverContext); ok {


### PR DESCRIPTION
This pull request adds closing the database connection after receiving the driver. If this is not done, goroutines will leak.

Code for reproduce:
```
package main

import (
	"fmt"
	_ "github.com/go-sql-driver/mysql"
	"github.com/uptrace/opentelemetry-go-extra/otelsql"
	"net/http"
	"net/http/pprof"
	"time"
)

func okHandler(w http.ResponseWriter, r *http.Request) {
	w.Write([]byte("ok"))
}

func main() {
	r := http.NewServeMux()
	r.HandleFunc("/", okHandler)

	r.HandleFunc("/debug/pprof/", pprof.Index)
	r.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
	r.HandleFunc("/debug/pprof/profile", pprof.Profile)
	r.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
	r.HandleFunc("/debug/pprof/trace", pprof.Trace)

	go func() {
		for {
			time.Sleep(time.Second)
			mysql, err := otelsql.Open("mysql", "user:12345@tcp(localhost:3306)/service")
			if err != nil {
				fmt.Println(err)
			}
			mysql.Close()
		}
	}()

	http.ListenAndServe(":8080", r)
}
```
Go to http://localhost:8080/debug/pprof/ and watch the goroutines grow. 