### PR TITLE
fix(otelsql): record error and status when SQL returns an error

### DIFF
--- a/otelsql/otel.go
+++ b/otelsql/otel.go
@@ -101,7 +101,7 @@ func (t *dbInstrum) withSpan(
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(attrs...))
 	err := fn(ctx, span)
-	span.End()
+	defer span.End()
 
 	if query != "" {
 		t.queryHistogram.Record(ctx, time.Since(startTime).Milliseconds(), metric.WithAttributes(t.attrs...))


### PR DESCRIPTION
The Span ends early when SQL returns an error, which prevents Otelsql from recording the error.
This commit fixes this issue by deferring the Span.End() call.

Fixes: #115