### PR TITLE
fix(otelgorm): Make metric reporting work with prepared statements

### DIFF
--- a/otelgorm/otelgorm.go
+++ b/otelgorm/otelgorm.go
@@ -55,8 +55,8 @@ type gormRegister interface {
 
 func (p otelPlugin) Initialize(db *gorm.DB) (err error) {
 	if !p.excludeMetrics {
-		if db, ok := db.ConnPool.(*sql.DB); ok {
-			otelsql.ReportDBStatsMetrics(db)
+		if sqlDB, err := db.DB(); err == nil {
+			otelsql.ReportDBStatsMetrics(sqlDB)
 		}
 	}
 


### PR DESCRIPTION
Previously we only initialized metrics reporting by calling otelsql.ReportDBStatsMetrics if the gorm.DB.ConnPool interface pointer we received happened to be a *sql.DB. This was often the case, but not if prepared statements were enabled (and possibly in other circumstances too). This caused metrics reporting to be silently disabled. We fix this by calling gorm.DB.DB whose sole purpose is to extract the underlying *sql.DB.