### PR TITLE
fix float32 zapcore field converter

### DIFF
--- a/otelzap/conv.go
+++ b/otelzap/conv.go
@@ -50,9 +50,12 @@ func appendField(kvs []log.KeyValue, f zapcore.Field) []log.KeyValue {
 		zapcore.UintptrType:
 		return append(kvs, log.Int64(f.Key, f.Integer))
 
-	case zapcore.Float32Type, zapcore.Float64Type:
+	case zapcore.Float64Type:
 		num := math.Float64frombits(uint64(f.Integer))
 		return append(kvs, log.Float64(f.Key, num))
+	case zapcore.Float32Type:
+		num := math.Float32frombits(uint32(f.Integer))
+		return append(kvs, log.Float64(f.Key, float64(num)))
 
 	case zapcore.Complex64Type:
 		str := strconv.FormatComplex(complex128(f.Interface.(complex64)), 'E', -1, 64)


### PR DESCRIPTION
I was using this library as an inspiration to write a converter for log fields for scenario in our company and I believe I found a bug, as float32 and float64 are encoded differently in zapcore Integer. Please see at your leisure