### PR TITLE
feat(otelsql): add span for rows.Close

### DIFF
--- a/otelsql/driver.go
+++ b/otelsql/driver.go
@@ -77,7 +77,7 @@ func (c *dsnConnector) Driver() driver.Driver {
 	return c.driver
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 type otelDriver struct {
 	driver    driver.Driver
@@ -113,7 +113,7 @@ func (d *otelDriver) OpenConnector(dsn string) (driver.Connector, error) {
 	return newConnector(d, connector, d.instrum), nil
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 type connector struct {
 	driver.Connector
@@ -148,7 +148,7 @@ func (c *connector) Driver() driver.Driver {
 	return c.driver
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 type otelConn struct {
 	driver.Conn
@@ -209,7 +209,7 @@ func (c *otelConn) createPingFunc(conn driver.Conn) pingFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.Execer = (*otelConn)(nil)
 
@@ -230,7 +230,7 @@ func (c *otelConn) createExecFunc(conn driver.Conn) execFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.ExecerContext = (*otelConn)(nil)
 
@@ -282,7 +282,7 @@ func (c *otelConn) createExecCtxFunc(conn driver.Conn) execCtxFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.Queryer = (*otelConn)(nil)
 
@@ -303,7 +303,7 @@ func (c *otelConn) createQueryFunc(conn driver.Conn) queryFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.QueryerContext = (*otelConn)(nil)
 
@@ -337,8 +337,8 @@ func (c *otelConn) createQueryCtxFunc(conn driver.Conn) queryCtxFunc {
 				var err error
 				rows, err = fn(ctx, query, args)
 				if err == nil {
-					_, rowsSpan := c.instrum.createSpan(ctx, "rows.Close", query)
-					rows = newCountableRows(rows, rowsSpan)
+					_, closeRowsSpan := c.instrum.createSpan(ctx, "rows.Close", query)
+					rows = newCountableRows(rows, closeRowsSpan)
 				}
 				return err
 			})
@@ -346,7 +346,7 @@ func (c *otelConn) createQueryCtxFunc(conn driver.Conn) queryCtxFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.ConnPrepareContext = (*otelConn)(nil)
 
@@ -414,7 +414,7 @@ func (c *otelConn) createBeginTxFunc(conn driver.Conn) beginTxFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.SessionResetter = (*otelConn)(nil)
 
@@ -435,7 +435,7 @@ func (c *otelConn) createResetSessionFunc(conn driver.Conn) resetSessionFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.NamedValueChecker = (*otelConn)(nil)
 
@@ -456,7 +456,7 @@ func (c *otelConn) createCheckNamedValueFunc(conn driver.Conn) checkNamedValueFu
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 func namedValueToValue(named []driver.NamedValue) ([]driver.Value, error) {
 	args := make([]driver.Value, len(named))

--- a/otelsql/driver.go
+++ b/otelsql/driver.go
@@ -337,7 +337,7 @@ func (c *otelConn) createQueryCtxFunc(conn driver.Conn) queryCtxFunc {
 				var err error
 				rows, err = fn(ctx, query, args)
 				if err == nil {
-					_, closeRowsSpan := c.instrum.createSpan(ctx, "rows.Close", query)
+					_, closeRowsSpan := c.instrum.createSpan(ctx, "rows", query)
 					rows = newCountableRows(rows, closeRowsSpan)
 				}
 				return err

--- a/otelsql/driver.go
+++ b/otelsql/driver.go
@@ -77,7 +77,7 @@ func (c *dsnConnector) Driver() driver.Driver {
 	return c.driver
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 type otelDriver struct {
 	driver    driver.Driver
@@ -113,7 +113,7 @@ func (d *otelDriver) OpenConnector(dsn string) (driver.Connector, error) {
 	return newConnector(d, connector, d.instrum), nil
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 type connector struct {
 	driver.Connector
@@ -148,7 +148,7 @@ func (c *connector) Driver() driver.Driver {
 	return c.driver
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 type otelConn struct {
 	driver.Conn
@@ -209,7 +209,7 @@ func (c *otelConn) createPingFunc(conn driver.Conn) pingFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.Execer = (*otelConn)(nil)
 
@@ -230,7 +230,7 @@ func (c *otelConn) createExecFunc(conn driver.Conn) execFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.ExecerContext = (*otelConn)(nil)
 
@@ -282,7 +282,7 @@ func (c *otelConn) createExecCtxFunc(conn driver.Conn) execCtxFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.Queryer = (*otelConn)(nil)
 
@@ -303,7 +303,7 @@ func (c *otelConn) createQueryFunc(conn driver.Conn) queryFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.QueryerContext = (*otelConn)(nil)
 
@@ -336,13 +336,17 @@ func (c *otelConn) createQueryCtxFunc(conn driver.Conn) queryCtxFunc {
 			func(ctx context.Context, span trace.Span) error {
 				var err error
 				rows, err = fn(ctx, query, args)
+				if err == nil {
+					_, rowsSpan := c.instrum.createSpan(ctx, "rows.Close", query)
+					rows = newCountableRows(rows, rowsSpan)
+				}
 				return err
 			})
 		return rows, err
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.ConnPrepareContext = (*otelConn)(nil)
 
@@ -410,7 +414,7 @@ func (c *otelConn) createBeginTxFunc(conn driver.Conn) beginTxFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.SessionResetter = (*otelConn)(nil)
 
@@ -431,7 +435,7 @@ func (c *otelConn) createResetSessionFunc(conn driver.Conn) resetSessionFunc {
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 var _ driver.NamedValueChecker = (*otelConn)(nil)
 
@@ -452,7 +456,7 @@ func (c *otelConn) createCheckNamedValueFunc(conn driver.Conn) checkNamedValueFu
 	}
 }
 
-//------------------------------------------------------------------------------
+// ------------------------------------------------------------------------------
 
 func namedValueToValue(named []driver.NamedValue) ([]driver.Value, error) {
 	args := make([]driver.Value, len(named))

--- a/otelsql/driver.go
+++ b/otelsql/driver.go
@@ -77,7 +77,7 @@ func (c *dsnConnector) Driver() driver.Driver {
 	return c.driver
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 type otelDriver struct {
 	driver    driver.Driver
@@ -113,7 +113,7 @@ func (d *otelDriver) OpenConnector(dsn string) (driver.Connector, error) {
 	return newConnector(d, connector, d.instrum), nil
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 type connector struct {
 	driver.Connector
@@ -148,7 +148,7 @@ func (c *connector) Driver() driver.Driver {
 	return c.driver
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 type otelConn struct {
 	driver.Conn
@@ -209,7 +209,7 @@ func (c *otelConn) createPingFunc(conn driver.Conn) pingFunc {
 	}
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 var _ driver.Execer = (*otelConn)(nil)
 
@@ -230,7 +230,7 @@ func (c *otelConn) createExecFunc(conn driver.Conn) execFunc {
 	}
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 var _ driver.ExecerContext = (*otelConn)(nil)
 
@@ -282,7 +282,7 @@ func (c *otelConn) createExecCtxFunc(conn driver.Conn) execCtxFunc {
 	}
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 var _ driver.Queryer = (*otelConn)(nil)
 
@@ -303,7 +303,7 @@ func (c *otelConn) createQueryFunc(conn driver.Conn) queryFunc {
 	}
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 var _ driver.QueryerContext = (*otelConn)(nil)
 
@@ -346,7 +346,7 @@ func (c *otelConn) createQueryCtxFunc(conn driver.Conn) queryCtxFunc {
 	}
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 var _ driver.ConnPrepareContext = (*otelConn)(nil)
 
@@ -414,7 +414,7 @@ func (c *otelConn) createBeginTxFunc(conn driver.Conn) beginTxFunc {
 	}
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 var _ driver.SessionResetter = (*otelConn)(nil)
 
@@ -435,7 +435,7 @@ func (c *otelConn) createResetSessionFunc(conn driver.Conn) resetSessionFunc {
 	}
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 var _ driver.NamedValueChecker = (*otelConn)(nil)
 
@@ -456,7 +456,7 @@ func (c *otelConn) createCheckNamedValueFunc(conn driver.Conn) checkNamedValueFu
 	}
 }
 
-// ------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 
 func namedValueToValue(named []driver.NamedValue) ([]driver.Value, error) {
 	args := make([]driver.Value, len(named))

--- a/otelsql/internal/e2e_test.go
+++ b/otelsql/internal/e2e_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"go.opentelemetry.io/otel/codes"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"

--- a/otelsql/internal/e2e_test.go
+++ b/otelsql/internal/e2e_test.go
@@ -110,6 +110,7 @@ func TestConn(t *testing.T) {
 					{name: "db.Prepare", stmt: "SELECT 1"},
 					{name: "stmt.Exec", stmt: "SELECT 1"},
 					{name: "stmt.Query", stmt: "SELECT 1"},
+					{name: "rows.Close", stmt: "SELECT 1"},
 				}
 				for i, wanted := range wanted {
 					span := spans[i]

--- a/otelsql/otel.go
+++ b/otelsql/otel.go
@@ -147,7 +147,7 @@ func WithTracerProvider(tracerProvider trace.TracerProvider) Option {
 	}
 }
 
-// WithAttributes configures attributes that are used to create a span.
+// WithAttributes configures attributes that are used to create a closeSpan.
 func WithAttributes(attrs ...attribute.KeyValue) Option {
 	return func(c *config) {
 		c.attrs = append(c.attrs, attrs...)

--- a/otelsql/otel.go
+++ b/otelsql/otel.go
@@ -18,8 +18,8 @@ import (
 const instrumName = "github.com/uptrace/opentelemetry-go-extra/otelsql"
 
 var (
-	dbRowsAffected   = attribute.Key("db.rows_affected")
-	dbRowsMarshalled = attribute.Key("db.rows_marshalled")
+	dbRowsAffected     = attribute.Key("db.rows_affected")
+	dbRowsUnmarshalled = attribute.Key("db.rows_unmarshalled")
 )
 
 type config struct {

--- a/otelsql/otel.go
+++ b/otelsql/otel.go
@@ -19,7 +19,7 @@ const instrumName = "github.com/uptrace/opentelemetry-go-extra/otelsql"
 
 var (
 	dbRowsAffected     = attribute.Key("db.rows_affected")
-	dbRowsUnmarshalled = attribute.Key("db.rows_unmarshalled")
+	dbRowsUnmarshalled = attribute.Key("db.rows_scanned")
 )
 
 type config struct {

--- a/otelsql/otel.go
+++ b/otelsql/otel.go
@@ -18,8 +18,8 @@ import (
 const instrumName = "github.com/uptrace/opentelemetry-go-extra/otelsql"
 
 var (
-	dbRowsAffected     = attribute.Key("db.rows_affected")
-	dbRowsUnmarshalled = attribute.Key("db.rows_scanned")
+	dbRowsAffected = attribute.Key("db.rows_affected")
+	dbRowsScanned  = attribute.Key("db.rows_scanned")
 )
 
 type config struct {

--- a/otelsql/rows.go
+++ b/otelsql/rows.go
@@ -33,7 +33,7 @@ func (c *countableRows) Close() error {
 		c.span.RecordError(err)
 	}
 
-	c.span.SetAttributes(dbRowsUnmarshalled.Int(c.count))
+	c.span.SetAttributes(dbRowsScanned.Int(c.count))
 
 	return err
 }

--- a/otelsql/rows.go
+++ b/otelsql/rows.go
@@ -1,0 +1,39 @@
+package otelsql
+
+import (
+	"database/sql/driver"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type countableRows struct {
+	rows driver.Rows
+	span trace.Span
+
+	count int
+}
+
+func newCountableRows(
+	rows driver.Rows,
+	span trace.Span,
+) *countableRows {
+	return &countableRows{rows: rows, span: span}
+}
+
+func (c *countableRows) Columns() []string {
+	return c.rows.Columns()
+}
+
+func (c *countableRows) Close() error {
+	c.span.SetAttributes(dbRowsMarshalled.Int(c.count))
+	c.span.End()
+
+	return c.rows.Close()
+}
+
+func (c *countableRows) Next(dest []driver.Value) error {
+	err := c.rows.Next(dest)
+	if err != nil {
+		c.count++
+	}
+	return err
+}

--- a/otelsql/rows.go
+++ b/otelsql/rows.go
@@ -24,15 +24,17 @@ func (c *countableRows) Columns() []string {
 }
 
 func (c *countableRows) Close() error {
-	c.span.SetAttributes(dbRowsMarshalled.Int(c.count))
-	c.span.End()
+	defer func() {
+		c.span.SetAttributes(dbRowsUnmarshalled.Int(c.count))
+		c.span.End()
+	}()
 
 	return c.rows.Close()
 }
 
 func (c *countableRows) Next(dest []driver.Value) error {
 	err := c.rows.Next(dest)
-	if err != nil {
+	if err == nil {
 		c.count++
 	}
 	return err

--- a/otelsql/rows.go
+++ b/otelsql/rows.go
@@ -7,17 +7,17 @@ import (
 )
 
 type countableRows struct {
-	rows driver.Rows
-	span trace.Span
+	rows      driver.Rows
+	closeSpan trace.Span
 
 	count int
 }
 
 func newCountableRows(
 	rows driver.Rows,
-	span trace.Span,
+	closeSpan trace.Span,
 ) *countableRows {
-	return &countableRows{rows: rows, span: span}
+	return &countableRows{rows: rows, closeSpan: closeSpan}
 }
 
 func (c *countableRows) Columns() []string {
@@ -26,8 +26,8 @@ func (c *countableRows) Columns() []string {
 
 func (c *countableRows) Close() error {
 	defer func() {
-		c.span.SetAttributes(dbRowsUnmarshalled.Int(c.count))
-		c.span.End()
+		c.closeSpan.SetAttributes(dbRowsUnmarshalled.Int(c.count))
+		c.closeSpan.End()
 	}()
 
 	return c.rows.Close()

--- a/otelsql/rows.go
+++ b/otelsql/rows.go
@@ -2,6 +2,7 @@ package otelsql
 
 import (
 	"database/sql/driver"
+
 	"go.opentelemetry.io/otel/trace"
 )
 

--- a/otelsql/stmt.go
+++ b/otelsql/stmt.go
@@ -114,7 +114,7 @@ func (s *otelStmt) createQueryCtxFunc(stmt driver.Stmt) stmtQueryCtxFunc {
 				var err error
 				rows, err = fn(ctx, args)
 				if err == nil {
-					_, closeRowsSpan := s.instrum.createSpan(ctx, "rows.Close", s.query)
+					_, closeRowsSpan := s.instrum.createSpan(ctx, "rows", s.query)
 					rows = newCountableRows(rows, closeRowsSpan)
 				}
 				return err

--- a/otelsql/stmt.go
+++ b/otelsql/stmt.go
@@ -113,11 +113,6 @@ func (s *otelStmt) createQueryCtxFunc(stmt driver.Stmt) stmtQueryCtxFunc {
 			func(ctx context.Context, span trace.Span) error {
 				var err error
 				rows, err = fn(ctx, args)
-				if err == nil {
-					_, rowsSpan := s.instrum.createSpan(ctx, "db.Unmarshal", s.query)
-
-					rows = newCountableRows(rows, rowsSpan)
-				}
 				return err
 			})
 		return rows, err

--- a/otelsql/stmt.go
+++ b/otelsql/stmt.go
@@ -113,6 +113,10 @@ func (s *otelStmt) createQueryCtxFunc(stmt driver.Stmt) stmtQueryCtxFunc {
 			func(ctx context.Context, span trace.Span) error {
 				var err error
 				rows, err = fn(ctx, args)
+				if err == nil {
+					_, closeRowsSpan := s.instrum.createSpan(ctx, "rows.Close", s.query)
+					rows = newCountableRows(rows, closeRowsSpan)
+				}
 				return err
 			})
 		return rows, err

--- a/otelsqlx/internal/e2e_test.go
+++ b/otelsqlx/internal/e2e_test.go
@@ -38,5 +38,5 @@ func TestE2E(t *testing.T) {
 	require.Equal(t, 3, len(spans))
 	require.Equal(t, "db.Connect", spans[0].Name())
 	require.Equal(t, "db.Query", spans[1].Name())
-	require.Equal(t, "rows.Close", spans[2].Name())
+	require.Equal(t, "rows", spans[2].Name())
 }

--- a/otelsqlx/internal/e2e_test.go
+++ b/otelsqlx/internal/e2e_test.go
@@ -35,7 +35,8 @@ func TestE2E(t *testing.T) {
 	require.Equal(t, "hello", person.Name)
 
 	spans := sr.Ended()
-	require.Equal(t, 2, len(spans))
+	require.Equal(t, 3, len(spans))
 	require.Equal(t, "db.Connect", spans[0].Name())
 	require.Equal(t, "db.Query", spans[1].Name())
+	require.Equal(t, "rows.Close", spans[2].Name())
 }


### PR DESCRIPTION
Hi 👋 

This PR adds span for `rows.Close` and saving count of rows in `db.rows_scanned` attribute.

This will help you better see how much time was spent processing the query.
